### PR TITLE
Add snapStop option, close #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,30 +42,35 @@ const snapConfig = {
   /**
    * snap-destination for x and y axes
    * should be a valid css value expressed as px|%|vw|vh
-   **/
+   */
   snapDestinationX: '0%',
   snapDestinationY: '90%',
   /**
    * time in ms after which scrolling is considered finished
    * [default: 100]
-   **/
+   */
   timeout: 100,
   /**
    * duration in ms for the smooth snap
    * [default: 300]
-   **/
+   */
   duration: 300,
   /**
    * threshold to reach before scrolling to next/prev element, expressed as a percentage in the range [0, 1]
    * [default: 0.2]
-   **/
+   */
   threshold: 0.2,
+  /**
+   * when true, the scroll container is not allowed to "pass over" the other snap positions
+   * [default: false]
+   */
+  snapStop: false,
   /**
    * custom easing function
    * [default: easeInOutQuad]
    * for reference: https://gist.github.com/gre/1650294
    * @param t normalized time typically in the range [0, 1]
-   **/
+   */
   easing: easeInOutQuad,
 }
 


### PR DESCRIPTION
You can now set a new optional parameter `snapStop` to true to prevent the scroll container to "pass over" the other snap positions, similarly to [CSS scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) property

Example:
```js
const element = document.getElementById('container')
const snapObject = new ScrollSnap(element, {
  snapDestinationY: '90%',
  snapStop: true,
}).bind()
```