### PR TITLE
add lastSnapPointX/Y option to disable snapping past this point

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ const snapConfig = {
    * @param t normalized time typically in the range [0, 1]
    */
   easing: easeInOutQuad,
+  /**
+   * last Snap Interval after which scroll snapping is disabled. first section is 0. default = Infinity means scroll snapping is never disabled.
+   */
+  lastSnapPointX: 4
+  lastSnapPointY: 5
 }
 
 function callback() {


### PR DESCRIPTION
This add the options `lastSnapPointX` and `lastSnapPointY` which when set will disable scroll snapping after the point (integer value).

For example If I have a website with vertical layout, passing `lastSnapPointY: 5` will snap normally for the 5 first snap points and then scrolling will be normal/free/without snapping.

Fixes issue #48