### PR TITLE
fix(typing): set callback as a optional argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ interface Coordinates {
 export default function createScrollSnap(
   element: HTMLElement,
   settings: Settings = {},
-  callback: () => void
+  callback?: () => void
 ) {
   const onAnimationEnd = typeof callback === 'function' ? callback : NOOP
 


### PR DESCRIPTION
The documentation mentions that the `callback` function is an optional option, but in the code this option is incorrectly set. This Pull Request aims to resolve this issue.